### PR TITLE
Refactor humann3 pipeline to allow for inclusion of metatranscriptome…

### DIFF
--- a/ocmsshotgun/modules/Humann3.py
+++ b/ocmsshotgun/modules/Humann3.py
@@ -3,40 +3,58 @@
 import os
 from cgatcore import pipeline as P
 
-class humann3():
-    def statement(infile, outfile, **PARAMS):
-        prefix = P.snip(os.path.basename(outfile), "_pathcoverage.tsv.gz")
-        outpath = os.path.dirname(os.path.abspath(outfile))
-                
-        db_metaphlan_path = PARAMS.get("humann3_db_metaphlan_path")
-        db_metaphlan_id = PARAMS.get("humann3_db_metaphlan_id")
-        db_nucleotide = PARAMS.get("humann3_db_nucleotide")
-        db_protein = PARAMS.get('humann3_db_protein')
-        search_mode = PARAMS.get('humann3_search_mode')
-        options = PARAMS.get("humann3_options")
-        statement = '''humann
-                    --input %(infile)s
-                    --output humann3.dir/%(prefix)s
-                    --nucleotide-database %(db_nucleotide)s
-                    --protein-database %(db_protein)s
-                    --metaphlan-options "--index %(db_metaphlan_id)s --bowtie2db=%(db_metaphlan_path)s"
-                    %(options)s;
-                    gzip %(outpath)s/%(prefix)s_pathcoverage.tsv;
-                    gzip %(outpath)s/%(prefix)s_pathabundance.tsv; 
-                    gzip %(outpath)s/%(prefix)s_genefamilies.tsv;
-                    gzip %(outpath)s/%(prefix)s_humann_temp/%(prefix)s_metaphlan_bugs_list.tsv;
-                    mv %(outpath)s/%(prefix)s_humann_temp/%(prefix)s_metaphlan_bugs_list.tsv.gz %(outpath)s;
-                    tar -zcvf %(outpath)s/%(prefix)s_humann_temp.tar.gz %(outpath)s/%(prefix)s_humann_temp;
-                    rm -r %(outpath)s/%(prefix)s_humann_temp
-        '''
+class humann3(object):
+    def __init__(self, infile, outfile, taxonomic_profile=None, **PARAMS):
+        self.infile = infile
+        self.prefix = P.snip(outfile, '_pathcoverage.tsv.gz', strip_path=True)
+        self.outpath = os.path.dirname(os.path.abspath(outfile))
+        self.PARAMS = PARAMS
+        self.taxonomic_profile = taxonomic_profile
+        
+    def buildStatement(self):
+        infile = self.infile
+        prefix = self.prefix
+        db_metaphlan_path = self.PARAMS["humann3_db_metaphlan_path"]
+        db_metaphlan_id = self.PARAMS["humann3_db_metaphlan_id"]
+        db_nucleotide = self.PARAMS["humann3_db_nucleotide"]
+        db_protein = self.PARAMS['humann3_db_protein']
+        search_mode = self.PARAMS['humann3_search_mode']
+        options = self.PARAMS["humann3_options"]
+
+        # the option to add a taxonomic profile for restricting mapping
+        if self.taxonomic_profile:
+            options = '--taxonomic-profile %s' % self.taxonomic_profile \
+                + ' ' + options
+        
+        statement = ("humann"
+                     " --input %(infile)s"
+                     " --output humann3.dir/%(prefix)s"
+                     " --nucleotide-database %(db_nucleotide)s"
+                     " --protein-database %(db_protein)s"
+                     " --search-mode %(search_mode)s"
+                     " --metaphlan-options  \"--index %(db_metaphlan_id)s --bowtie2db=%(db_metaphlan_path)s\""
+                     " %(options)s" % locals())
+        
         return statement
 
-    def run(infile, outfile, **PARAMS):
+    def postProcess(self):
+        prefix = self.prefix
+        outpath = self.outpath
+        
+        statement =  ("gzip %(outpath)s/%(prefix)s_pathcoverage.tsv &&"
+                      " gzip %(outpath)s/%(prefix)s_pathabundance.tsv &&" 
+                      " gzip %(outpath)s/%(prefix)s_genefamilies.tsv &&"
+                      " gzip %(outpath)s/%(prefix)s_humann_temp/%(prefix)s_metaphlan_bugs_list.tsv &&"
+                      " mv %(outpath)s/%(prefix)s_humann_temp/%(prefix)s_metaphlan_bugs_list.tsv.gz %(outpath)s &&"
+                      " tar -zcvf %(outpath)s/%(prefix)s_humann_temp.tar.gz %(outpath)s/%(prefix)s_humann_temp &&"
+                      " rm -rf %(outpath)s/%(prefix)s_humann_temp" % locals())
+
+        return statement
+    
+    def run(self):
         '''functional profile with humann3
         '''
         
-        statement = self.statement(infile, outfile, **PARAMS)
-        P.run(statement,
-              job_memory=PARAMS.get("humann3_job_memory"),
-              job_threads=PARAMS.get("humann3_job_threads"),
-              job_options=PARAMS.get('humann3_job_options','')
+        statement = self.buildStatement() + ' && ' + self.postProcess()
+
+        return statement

--- a/ocmsshotgun/pipeline_humann3/pipeline.yml
+++ b/ocmsshotgun/pipeline_humann3/pipeline.yml
@@ -1,3 +1,8 @@
+location:
+    input: input.dir
+    
+    transcriptome: input_mtx.dir
+
 humann3:
 
     # database settings
@@ -5,6 +10,7 @@ humann3:
     db_metaphlan_id: mpa_v31_CHOCOPhlAn_201901
     db_nucleotide: /well/kir/mirror/humann3/chocophlan 
     db_protein: /well/kir/mirror/humann3/uniref/uniref90
+    search_mode: uniref90
 
     # additional humann3 options
     options: ""
@@ -13,10 +19,8 @@ humann3:
     job_memory: 40G
     job_threads: 4
 
-merge:
-    # job options of tasks that merge humann3 outputs
-    job_memory: 8G
-    job_threads: 1
+    # location of uniref2ko mapping file
+    uniref_to_ko: /gpfs3/well/kir-ocms/shared/tmp/map_ko_uniref90.txt.gz
 
 report:
     # prefix to use for publishing the report from this pipeline

--- a/ocmsshotgun/scripts/split_metaphlan.py
+++ b/ocmsshotgun/scripts/split_metaphlan.py
@@ -56,13 +56,13 @@ def main(argv=None):
         os.makedirs(args.outdir)
 
     # initialise file for each tax level
-    kingdom_file = open(os.path.join(args.outdir, "merged_metaphlan_kingdom.tsv"), "w")
-    phylum_file = open(os.path.join(args.outdir, "merged_metaphlan_phylum.tsv"), "w")
-    class_file = open(os.path.join(args.outdir, "merged_metaphlan_class.tsv"), "w")
-    order_file = open(os.path.join(args.outdir, "merged_metaphlan_order.tsv"), "w")
-    family_file = open(os.path.join(args.outdir, "merged_metaphlan_family.tsv"), "w")
-    genus_file = open(os.path.join(args.outdir, "merged_metaphlan_genus.tsv"), "w")
-    species_file = open(os.path.join(args.outdir, "merged_metaphlan_species.tsv"), "w")
+    kingdom_file = open(os.path.join(args.outdir, "metaphlan_kingdom.tsv"), "w")
+    phylum_file = open(os.path.join(args.outdir, "metaphlan_phylum.tsv"), "w")
+    class_file = open(os.path.join(args.outdir, "metaphlan_class.tsv"), "w")
+    order_file = open(os.path.join(args.outdir, "metaphlan_order.tsv"), "w")
+    family_file = open(os.path.join(args.outdir, "metaphlan_family.tsv"), "w")
+    genus_file = open(os.path.join(args.outdir, "metaphlan_genus.tsv"), "w")
+    species_file = open(os.path.join(args.outdir, "metaphlan_species.tsv"), "w")
 
     out_list = [kingdom_file, phylum_file, class_file, order_file, family_file, genus_file, species_file]
 
@@ -91,6 +91,8 @@ def main(argv=None):
                 phylum_file.write(line)
             elif "k__" in line:
                 kingdom_file.write(line)
+            else:
+                raise ValueError("Unexpected line format in merged input: %s" % line)
 
     # close files
     for of in out_list:


### PR DESCRIPTION
1) Added merging of fastqs as a pipeline step with implicit handling of fastq.1 fastq.2 fastq.3 
2) Fixed humann3 base class
3) Added options to integrate metagenome and metatranscriptome data based on shared filenames
4) Moved merging downstream of metatranscriptome output and resorted to internal humann/metaphlan merge scripts.
5) Added genefamily to KO mapping as a default pipeline step
6) Added RPK to CPM normalisation for humann3 output as default.