### PR TITLE
updates to incorporate some potential bugs in bmtagger.sh and introdu…

### DIFF
--- a/ocmsshotgun/modules/PreProcess.py
+++ b/ocmsshotgun/modules/PreProcess.py
@@ -390,6 +390,9 @@ class bmtagger(utility.matchReference):
 
         fastq1 = self.fastq1
         outfile = self.outfile
+        bmtagger_exec = self.PARAMS['bmtagger_executable']
+        assert bmtagger_exec in ["bmtagger.sh", "bmtagger_mod.sh"], "must specify bmtagger.sh or bmtagger_mod.sh"
+
         if self.fastq2:
             fastq2 = self.fastq2
             fastq3 = self.fastq3
@@ -401,7 +404,7 @@ class bmtagger(utility.matchReference):
             # In some cases, it may be desirable to screen against multiple hosts.
             indexes = zip(self.PARAMS['bmtagger_bitmask'].split(','),
                           self.PARAMS['bmtagger_srprism'].split(','))
-            
+           
             statements=[]
             for n, indexes in enumerate(indexes, 1):
                 n = str(n)
@@ -420,7 +423,7 @@ class bmtagger(utility.matchReference):
                 # It also fails if fastq1 header differs from fastq2
                 statement1 = ("zcat %(fastq1)s > %(tmpf1)s &&"
                               " zcat %(fastq2)s > %(tmpf2)s &&"
-                              " bmtagger.sh"
+                              " %(bmtagger_exec)s"
                               "  -b %(bitmask)s"
                               "  -x %(srprism)s"
                               "  -T %(tmpdir1)s"
@@ -437,7 +440,7 @@ class bmtagger(utility.matchReference):
                 # Screen the singletons
                 if os.path.exists(self.fastq3) and IOTools.open_file(self.fastq3).read(1):
                     statement2 = ("zcat %(fastq3)s > %(tmpf3)s &&"
-                                  " bmtagger.sh"
+                                  " %(bmtagger_exec)s"
                                   "  -b %(bitmask)s"
                                   "  -x %(srprism)s"
                                   "  -T %(tmpdir2)s"
@@ -471,7 +474,7 @@ class bmtagger(utility.matchReference):
                 tmpf = P.get_temp_filename('.')
                 
                 statement = ("zcat %(fastq1)s > %(tmpf)s &&"
-                             " bmtagger.sh"
+                             " %(bmtagger_exec)s"
                              "  -b %(bitmask)s"
                              "  -x %(srprism)s"
                              "  -T %(tmpdir1)s"
@@ -731,18 +734,18 @@ def summariseReadCounts(infiles, outfile):
             masked = df.loc['masked', 1]
             input_reads = df.loc['input', 1]
             
-            lost_dup = input_reads - deduped
-            lost_adapt = deduped - deadapt
-            lost_rrna = deadapt - rrna
-            lost_host = rrna - dehost
-            lost_mask = dehost - masked
+            lost_dup = int(input_reads) - int(deduped)
+            lost_adapt = int(deduped) - int(deadapt)
+            lost_rrna = int(deadapt) - int(rrna)
+            lost_host = int(rrna) - int(dehost)
+            lost_mask = int(dehost) - int(masked)
 
             lost_dup_perc = round(lost_dup/float(input_reads) * 100, 2)
             lost_adapt_perc = round(lost_adapt/float(input_reads) * 100, 2)
             lost_rrna_perc = round(lost_rrna/float(input_reads) * 100, 2)
             lost_host_perc = round(lost_host/float(input_reads) * 100, 2)
             lost_mask_perc = round(lost_mask/float(input_reads) * 100, 2)
-            output_perc = round(masked/float(input_reads) * 100, 2)
+            output_perc = round(float(masked)/float(input_reads) * 100, 2)
 
             outf.write('\t'.join(map(str, [sample_id, input_reads, masked, 
                                            lost_dup, lost_adapt, lost_rrna, 

--- a/ocmsshotgun/pipeline_kraken2.py
+++ b/ocmsshotgun/pipeline_kraken2.py
@@ -146,7 +146,7 @@ def mergeBracken(infiles, outfile):
     sample_names = [P.snip(x, "." + level) for x in sample_names]
     titles = ",".join([x for x in sample_names])
 
-    statement = '''  cgat combine_tables
+    statement = '''  cgat tables2table
                      --glob=bracken.dir/*.abundance.%(level)s.tsv
                      --skip-titles
                      --header-names=%(titles)s

--- a/ocmsshotgun/pipeline_preprocess.py
+++ b/ocmsshotgun/pipeline_preprocess.py
@@ -190,7 +190,7 @@ def combineRNAClassification(infiles, outfile):
 
     infiles = ' '.join(infiles)
 
-    statement = ("cgat combine_tables"
+    statement = ("cgat tables2table"
                  "  --log=%(outfile)s.log"
                  "  %(infiles)s |"
                  " gzip > %(outfile)s")
@@ -258,9 +258,12 @@ def maskLowComplexity(fastq1, outfile):
            r"read_count_summary.dir/\1_input.nreads")
 def countInputReads(infile, outfile):
     
+    outf = open(outfile, "w")
+    outf.write("nreads\n")
+    outf.close()
     statement = ("zcat %(infile)s |"
                  " awk '{n+=1;} END {printf(n/4\"\\n\");}'"
-                 " > %(outfile)s")
+                 " >> %(outfile)s")
 
     P.run(statement)
 
@@ -272,9 +275,13 @@ def countInputReads(infile, outfile):
            r'read_count_summary.dir/\1.nreads')
 def countOutputReads(infile, outfile):
     '''Count the number of reads in the output files'''    
+    
+    outf = open(outfile, "w")
+    outf.write("nreads\n")
+    outf.close()
     statement = ("zcat %(infile)s |"
                  " awk '{n+=1;} END {printf(n/4\"\\n\");}'"
-                 " > %(outfile)s")
+                 " >> %(outfile)s")
 
     P.run(statement)
 
@@ -286,7 +293,7 @@ def collateReadCounts(infiles, outfile):
 
     infiles = ' '.join(infiles)
     
-    statement = ("cgat combine_tables"
+    statement = ("cgat tables2table"
                  " --cat Step"
                  " --regex-filename='.+_(.+)\.nreads'"
                  " --no-titles"

--- a/ocmsshotgun/pipeline_preprocess/pipeline.yml
+++ b/ocmsshotgun/pipeline_preprocess/pipeline.yml
@@ -117,6 +117,10 @@ bmtagger:
     # Set to true if you want to keep reads who's pair is host (currently disabled)
     # keep_pairs: ''
 
+    # which executable to use - bmtagger_mod.sh fixes some apparent
+    # bugs. Choices are bmtagger.sh or bmtagger_mod.sh
+    executable: bmtagger.sh
+
     # Comma-separated list of genomes to screen against
     bitmask: /gpfs3/well/johnson/shared/mirror/genome/bmtagger/bitmask/hg38.bitmask
 


### PR DESCRIPTION
Additions in this commit:

1. There appeared to be some bugs in bmtagger.sh which meant that it was calling srprism with incorrect arguments (at least for the version of srprism that is installed) and also not reading the srprismopts properly. The updates here add an option in the pipeline_preprocess.py pipeline.yml to choose whether to use the bmtagger.sh or bmtagger_mod.sh (corrected the errors in the bmtagger.sh script). 

2. cgat combine_tables is now deprecated and so this update moves to cgat tables2table which is essentially the same script but uses pandas to read in tables. The reading in of tables was a bit off with the original pipeline_preprocess and so various bits of PreProcess.py and pipeline_preprocess.py have been changed so that it works and doesn't return an empty dataframe.

The pipeline runs through on some test data so hopefully nothing is broken :)