### PR TITLE
{nei}combine tables

### DIFF
--- a/ocmsshotgun/pipeline_kraken2.py
+++ b/ocmsshotgun/pipeline_kraken2.py
@@ -146,7 +146,7 @@ def mergeBracken(infiles, outfile):
     sample_names = [P.snip(x, "." + level) for x in sample_names]
     titles = ",".join([x for x in sample_names])
 
-    statement = '''  cgat tables2table
+    statement = '''  ocms_shotgun combine_tables
                      --glob=bracken.dir/*.abundance.%(level)s.tsv
                      --skip-titles
                      --header-names=%(titles)s

--- a/ocmsshotgun/scripts/combine_tables.py
+++ b/ocmsshotgun/scripts/combine_tables.py
@@ -1,0 +1,51 @@
+## This script was lifted from https://github.com/cgat-developers/cgat-apps
+## in order to remove the cgat-apps dependency from OCMS_16S and without
+## having to re-write the tool.
+
+## Copyright (c) 2021 cgat-developers
+
+'''combine_tables.py - join tables
+===============================
+
+:Tags: Python
+
+Purpose
+-------
+
+This script reads several tab-separated tables and joins them into a
+single one.
+
+.. todo::
+
+   * Rename to tables2table.py
+   * Use pandas dataframes for fast IO and merging/joining
+
+Usage
+-----
+
+The option ``--header-names`` sets the column titles explicitely. Add
+``--skip-titles`` if you want to avoid echoing the original title in
+the input files.
+
+
+Example::
+
+   python combine_tables.py --help
+
+Type::
+
+   python combine_tables.py --help
+
+for command line help.
+
+Command line options
+--------------------
+
+'''
+
+import sys
+from cgatcore.tables import main
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
I added combine_tables.py to the repository so that merging bracken output used the script in this repo. This is probably a temporary fix until tables2table in cgat-apps is updated and functional.