### PR TITLE
Fix duplicated -phred argument in Trimmomatic single-end statement

### DIFF
--- a/ocmsshotgun/modules/PreProcess.py
+++ b/ocmsshotgun/modules/PreProcess.py
@@ -138,7 +138,7 @@ class trimmomatic(utility.matchReference):
         else:
             statement = ("java -Xmx5g -jar %(trimmomatic_jar_path)s PE"
                          " -threads %(trimmomatic_n_threads)s"
-                         " -phred%(phred_format)s"
+                         " %(phred_format)s"
                          " -trimlog %(logfile)s"
                          " %(fastq1)s" # input read 1
                          " %(outfile1)s" # output read 1


### PR DESCRIPTION
When processing single-end reads, the pipeline was incorrectly constructing the Trimmomatic command with -phred-phred33 instead of the correct -phred33, causing it to fail.
Fix: Removed the duplicated -phred prefix in the else block of the trimmomatic class where single-end reads are handled.
Tested: Successfully ran Trimmomatic on a single-end sample after this change.