### PR TITLE
1 - changed the way the file prefix was defined in Humann3 class. 2 -…

### DIFF
--- a/ocmsshotgun/modules/Humann3.py
+++ b/ocmsshotgun/modules/Humann3.py
@@ -17,7 +17,7 @@ class Humann3(Utility.BaseTool):
 
         # input is always fasta or fastq so can use the prefix
         # from that object
-        self.prefix = Utility.MetaFastn(infile).prefix
+        fastn_obj.prefix = Utility.MetaFastn(infile).prefix
 
     def concat_fastqs(self, fastn_obj):
         '''
@@ -66,7 +66,7 @@ class Humann3(Utility.BaseTool):
                      f" --threads {threads}"
                      f" --metaphlan-options  \"--index {db_metaphlan_id}"
                      f" --bowtie2db={db_metaphlan_path}\""
-                     f" {options} 2> {self.outdir}/{self.prefix}.log")
+                     f" {options} 2> {self.outdir}/{fastn_obj.prefix}.log")
         
         return statement
 
@@ -75,19 +75,19 @@ class Humann3(Utility.BaseTool):
         if self.taxonomic_profile:
             options = ""
         else:
-            metaphlan_bugs_list = (f"{self.outdir}/{self.prefix}_humann_temp/"
-                                   f"{self.prefix}_metaphlan_bugs_list.tsv")
+            metaphlan_bugs_list = (f"{self.outdir}/{fastn_obj.prefix}_humann_temp/"
+                                   f"{fastn_obj.prefix}_metaphlan_bugs_list.tsv")
             options = (f" gzip {metaphlan_bugs_list} &&"
                        f" mv {metaphlan_bugs_list}.gz {self.outdir} &&")
         
-        humann_log = (f"{self.outdir}/{self.prefix}_humann_temp/"
-                      f"{self.prefix}.log")
-        humann_tmp = f"{self.outdir}/{self.prefix}_humann_temp"
+        humann_log = (f"{self.outdir}/{fastn_obj.prefix}_humann_temp/"
+                      f"{fastn_obj.prefix}.log")
+        humann_tmp = f"{self.outdir}/{fastn_obj.prefix}_humann_temp"
         statement =  (
             f"mv {humann_log} {self.outdir} &&"
-            f" gzip {self.outdir}/{self.prefix}_pathcoverage.tsv &&"
-            f" gzip {self.outdir}/{self.prefix}_pathabundance.tsv &&" 
-            f" gzip {self.outdir}/{self.prefix}_genefamilies.tsv &&"
+            f" gzip {self.outdir}/{fastn_obj.prefix}_pathcoverage.tsv &&"
+            f" gzip {self.outdir}/{fastn_obj.prefix}_pathabundance.tsv &&" 
+            f" gzip {self.outdir}/{fastn_obj.prefix}_genefamilies.tsv &&"
             f" {options}"
             f" tar -zcvf {humann_tmp}.tar.gz {humann_tmp} &&"
             f" rm -rf {humann_tmp}"

--- a/ocmsshotgun/modules/Humann3.py
+++ b/ocmsshotgun/modules/Humann3.py
@@ -68,7 +68,7 @@ class Humann3(Utility.BaseTool):
 
     def post_process(self):
 
-        prefix = P.snip(self.outfile, '_pathcoverage.tsv.gz')
+        prefix = P.snip(os.path.basename(self.outfile), '_pathcoverage.tsv.gz')
         if self.taxonomic_profile:
             options = ""
         else:

--- a/ocmsshotgun/modules/Humann3.py
+++ b/ocmsshotgun/modules/Humann3.py
@@ -15,10 +15,6 @@ class Humann3(Utility.BaseTool):
 
         self.taxonomic_profile = taxonomic_profile
 
-        # input is always fasta or fastq so can use the prefix
-        # from that object
-        fastn_obj.prefix = Utility.MetaFastn(infile).prefix
-
     def concat_fastqs(self, fastn_obj):
         '''
         Method to concatenate fastq files - symlink if there is
@@ -72,22 +68,23 @@ class Humann3(Utility.BaseTool):
 
     def post_process(self):
 
+        prefix = P.snip(self.outfile, '_pathcoverage.tsv.gz')
         if self.taxonomic_profile:
             options = ""
         else:
-            metaphlan_bugs_list = (f"{self.outdir}/{fastn_obj.prefix}_humann_temp/"
-                                   f"{fastn_obj.prefix}_metaphlan_bugs_list.tsv")
+            metaphlan_bugs_list = (f"{self.outdir}/{prefix}_humann_temp/"
+                                   f"{prefix}_metaphlan_bugs_list.tsv")
             options = (f" gzip {metaphlan_bugs_list} &&"
                        f" mv {metaphlan_bugs_list}.gz {self.outdir} &&")
         
-        humann_log = (f"{self.outdir}/{fastn_obj.prefix}_humann_temp/"
-                      f"{fastn_obj.prefix}.log")
-        humann_tmp = f"{self.outdir}/{fastn_obj.prefix}_humann_temp"
+        humann_log = (f"{self.outdir}/{prefix}_humann_temp/"
+                      f"{prefix}.log")
+        humann_tmp = f"{self.outdir}/{prefix}_humann_temp"
         statement =  (
             f"mv {humann_log} {self.outdir} &&"
-            f" gzip {self.outdir}/{fastn_obj.prefix}_pathcoverage.tsv &&"
-            f" gzip {self.outdir}/{fastn_obj.prefix}_pathabundance.tsv &&" 
-            f" gzip {self.outdir}/{fastn_obj.prefix}_genefamilies.tsv &&"
+            f" gzip {self.outdir}/{prefix}_pathcoverage.tsv &&"
+            f" gzip {self.outdir}/{prefix}_pathabundance.tsv &&" 
+            f" gzip {self.outdir}/{prefix}_genefamilies.tsv &&"
             f" {options}"
             f" tar -zcvf {humann_tmp}.tar.gz {humann_tmp} &&"
             f" rm -rf {humann_tmp}"

--- a/ocmsshotgun/pipeline_humann3.py
+++ b/ocmsshotgun/pipeline_humann3.py
@@ -97,7 +97,7 @@ def poolInputFastqs(infile, outfile):
     '''Humann relies on pooling input files'''
 
     tool = H.Humann3(infile, outfile, **PARAMS)
-    statement = tool.concat_fastq(Utility.MetaFastn(infile))
+    statement = tool.concat_fastqs(Utility.MetaFastn(infile))
     P.run(statement)
     
 ###############################################################################
@@ -146,7 +146,7 @@ def poolTranscriptomeFastqs(infile, outfile):
     os.mkdir(outdir)
     
     tool = H.Humann3(infile, outfile, **PARAMS)
-    statement = tool.concat_fastq(Utilily.MetaFastn(infile))
+    statement = tool.concat_fastqs(Utilily.MetaFastn(infile))
     P.run(statement)
  
 

--- a/ocmsshotgun/pipeline_humann3/pipeline.yml
+++ b/ocmsshotgun/pipeline_humann3/pipeline.yml
@@ -18,7 +18,7 @@ humann3:
     remove_humann_temp: True
 
     # additional humann3 options
-    options: "--threads 8"
+    options: ""
     
     # job options
     job_memory: 40G

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 setup(
     # package information
     name='ocms_shotgun',
-    version="1.0.0",
+    version="1.0.1",
     description='OCMS_Shotgun : Oxford Centre for Microbiome Studies pipelines for shotgun metagenome processing',
     author='Sandi Yen, Nicholas Ilott, Jethro Johnson',
     license="MIT",


### PR DESCRIPTION
… concat_fastqs was missing the s and so wasn't being found.

There is still a bug in how single-end files are handled as input but this will be dealt with in another branch. It is a bit of an issue because the regex in the humann3 pipeline is trying to find .1.gz files so there are likely a few changes to be made to handle single-end reads.