### PR TITLE
adding try catch to reading pipeline.yml so can create config without…

### DIFF
--- a/ocmsshotgun/modules/PreProcess.py
+++ b/ocmsshotgun/modules/PreProcess.py
@@ -1,13 +1,8 @@
 # Module for generic shotgun preprocessing steps
 
-import os,sys,re
+import os,re
 import shutil
-import itertools
-import sqlite3
-import distutils
 import pandas as pd
-import errno
-import json
 from glob import glob
 from cgatcore import pipeline as P
 from cgatcore import iotools as IOTools

--- a/ocmsshotgun/pipeline_concatfastq.py
+++ b/ocmsshotgun/pipeline_concatfastq.py
@@ -53,6 +53,7 @@ import sys
 import os
 from ruffus import *
 from cgatcore import pipeline as P 
+from cgatcore import iotools as IOTools
 import ocmsshotgun.modules.Humann3 as H
 import ocmstoolkit.modules.Utility as Utility
 # no params in config needed but putting here in case that changes

--- a/ocmsshotgun/pipeline_concatfastq.py
+++ b/ocmsshotgun/pipeline_concatfastq.py
@@ -57,12 +57,15 @@ import ocmsshotgun.modules.Humann3 as H
 import ocmstoolkit.modules.Utility as Utility
 # no params in config needed but putting here in case that changes
 PARAMS = P.get_parameters(["pipeline.yml"])
-
-# set input directory
-indir = PARAMS.get('general_input.dir', 'input.dir')
-
-# get all sequence files within directory to process
-SEQUENCEFILES = Utility.get_fastns(indir)
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    indir = "."
+    FASTQ1S = None
+else:
+    # check that input files correspond
+    indir = PARAMS.get("general_input.dir", "input.dir")
+    FASTQ1S = Utility.get_fastns(indir, 1,2)
 
 ######################################################
 ######################################################
@@ -76,8 +79,8 @@ SEQUENCEFILES = Utility.get_fastns(indir)
 ######################################################
 
 @follows(mkdir("concat_fastq.dir"))
-@transform(SEQUENCEFILES, 
-         regex(fr"{indir}/(\S+)\.(fastq.1.gz)"),
+@transform(FASTQ1S, 
+         regex(r".+/(\S+)\.(fastq.1.gz)"),
          r"concat_fastq.dir/\1.fastq.gz")
 def concatFastq(infile, outfile):
     """Expects paired end fastq files to be in format fastq.1.gz, fastq.2.gz

--- a/ocmsshotgun/pipeline_databases.py
+++ b/ocmsshotgun/pipeline_databases.py
@@ -60,17 +60,18 @@ from cgatcore import iotools as IOTools
 
 PARAMS = P.get_parameters(["pipeline.yml"])
 
-try:
-    IOTools.open_file("pipeline.yml")
-except FileNotFoundError as e:
-    raise RuntimeError("pipeline.yml not found in run directory. \
-                       please run 'ocms_shotgun databases config'")    
-
 ########################################################
 ########################################################
 # get the general information on versions etc
 ########################################################
 ########################################################
+
+
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    # allow config to make yml
+    pass
 
 gcc_version = PARAMS["gcc"]
 python_version = PARAMS["python"]

--- a/ocmsshotgun/pipeline_databases.py
+++ b/ocmsshotgun/pipeline_databases.py
@@ -56,7 +56,15 @@ from pathlib import Path
 from ruffus import *
 import ocmsshotgun.modules.Databases as DB
 from cgatcore import pipeline as P
+from cgatcore import iotools as IOTools
+
 PARAMS = P.get_parameters(["pipeline.yml"])
+
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    raise RuntimeError("pipeline.yml not found in run directory. \
+                       please run 'ocms_shotgun databases config'")    
 
 ########################################################
 ########################################################

--- a/ocmsshotgun/pipeline_hisat2.py
+++ b/ocmsshotgun/pipeline_hisat2.py
@@ -45,12 +45,16 @@ import os,sys,re
 import ocmstoolkit.modules.Utility as Utility
 import ocmsshotgun.modules.PreProcess as PP
 
-# set up params
 PARAMS = P.get_parameters(["pipeline.yml"])
-
-# check that input files correspond
-indir = PARAMS.get("general_input.dir", "input.dir")
-FASTQ1S = Utility.get_fastns(indir)
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    indir = "."
+    FASTQ1S = None
+else:
+    # check that input files correspond
+    indir = PARAMS.get("general_input.dir", "input.dir")
+    FASTQ1S = Utility.get_fastns(indir)
 
 @follows(mkdir('hisat2.dir'))
 @transform(FASTQ1S,

--- a/ocmsshotgun/pipeline_humann3.py
+++ b/ocmsshotgun/pipeline_humann3.py
@@ -138,7 +138,7 @@ def runHumann3(infile, outfiles):
 # Run humann3 on metatranscriptome data
 ###############################################################################
 @active_if(PARAMS['general_transcriptome'])    
-@transform(FASTQ2S,
+@transform(FASTQ1S,
            regex(".+/(.+).fastq.1.gz"),
            r"input_mtx_merged.dir/\1.fastq.gz")
 def poolTranscriptomeFastqs(infile, outfile):

--- a/ocmsshotgun/pipeline_humann3.py
+++ b/ocmsshotgun/pipeline_humann3.py
@@ -87,15 +87,15 @@ else:
     FASTQ1S = Utility.get_fastns(indir)
 
     if PARAMS['general_transcriptome']:
-        FASTQ2s = Utility.get_fastns(PARAMS['general_transcriptome'])
+        FASTQ2S = Utility.get_fastns(PARAMS['general_transcriptome'])
     else:
-        FASTQ2s = None
+        FASTQ2S = None
 
 ###############################################################################
 # Run humann3 on concatenated fastq.gz
 ###############################################################################
 @follows(mkdir("input_merged.dir"))
-@transform(FASTQ1s,
+@transform(FASTQ1S,
            regex(".+/(.+).fastq.1.gz"),
            r"input_merged.dir/\1.fastq.gz")
 def poolInputFastqs(infile, outfile):
@@ -138,7 +138,7 @@ def runHumann3(infile, outfiles):
 # Run humann3 on metatranscriptome data
 ###############################################################################
 @active_if(PARAMS['general_transcriptome'])    
-@transform(FASTQ2s,
+@transform(FASTQ2S,
            regex(".+/(.+).fastq.1.gz"),
            r"input_mtx_merged.dir/\1.fastq.gz")
 def poolTranscriptomeFastqs(infile, outfile):

--- a/ocmsshotgun/pipeline_humann3.py
+++ b/ocmsshotgun/pipeline_humann3.py
@@ -76,22 +76,27 @@ import ocmsshotgun.modules.Humann3 as H
 
 # load options from the config file
 PARAMS = P.get_parameters(["pipeline.yml"])
-indir = PARAMS.get('general_input.dir','input.dir')
-
-# check all files to be processed
-FASTQ1s = Utility.get_fastns(indir)
-
-if PARAMS['general_transcriptome']:
-    FASTQ2s = Utility.get_fastns(PARAMS['general_transcriptome'])
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    indir = "."
+    FASTQ1S = None
 else:
-    FASTQ2s = None
+    # check that input files correspond
+    indir = PARAMS.get("general_input.dir", "input.dir")
+    FASTQ1S = Utility.get_fastns(indir)
+
+    if PARAMS['general_transcriptome']:
+        FASTQ2s = Utility.get_fastns(PARAMS['general_transcriptome'])
+    else:
+        FASTQ2s = None
 
 ###############################################################################
 # Run humann3 on concatenated fastq.gz
 ###############################################################################
 @follows(mkdir("input_merged.dir"))
 @transform(FASTQ1s,
-           regex(f"{indir}/(.+).fastq.1.gz"),
+           regex(".+/(.+).fastq.1.gz"),
            r"input_merged.dir/\1.fastq.gz")
 def poolInputFastqs(infile, outfile):
     '''Humann relies on pooling input files'''

--- a/ocmsshotgun/pipeline_humann3.py
+++ b/ocmsshotgun/pipeline_humann3.py
@@ -70,7 +70,7 @@ import re
 import shutil
 from ruffus import *
 from cgatcore import pipeline as P
-
+from cgatcore import iotools as IOTools
 import ocmstoolkit.modules.Utility as Utility
 import ocmsshotgun.modules.Humann3 as H
 

--- a/ocmsshotgun/pipeline_kraken2.py
+++ b/ocmsshotgun/pipeline_kraken2.py
@@ -57,17 +57,17 @@ from ruffus import *
 from cgatcore import pipeline as P
 import ocmsshotgun.modules.Kraken2 as K
 import ocmstoolkit.modules.Utility as Utility
+
 PARAMS = P.get_parameters(["pipeline.yml"])
-
-# check files to be processed
-indir = PARAMS.get('general_input.dir', 'input.dir')
-FASTQ1 = Utility.get_fastns(indir)
-
-#get all files within the directory to process
-SEQUENCEFILES = (f"{indir}/*.fastq.1.gz")
-
-SEQUENCEFILES_REGEX = regex(
-    fr"{indir}/(\S+).(fastq.1.gz)")
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    indir = "."
+    FASTQ1S = None
+else:
+    # check that input files correspond
+    indir = PARAMS.get("general_input.dir", "input.dir")
+    FASTQ1S = Utility.get_fastns(indir)
 
 ########################################################
 ########################################################
@@ -78,8 +78,8 @@ SEQUENCEFILES_REGEX = regex(
 ########################################################
 
 @follows(mkdir("kraken2.dir"))
-@transform(SEQUENCEFILES, 
-           SEQUENCEFILES_REGEX, 
+@transform(FASTQ1S, 
+           regex(r".+/(\S+).(fastq.1.gz)"), 
            r"kraken2.dir/\1.k2.report.tsv")
 def runKraken2(infile, outfile):
     '''classify reads with kraken2

--- a/ocmsshotgun/pipeline_kraken2.py
+++ b/ocmsshotgun/pipeline_kraken2.py
@@ -55,6 +55,7 @@ import os
 import glob
 from ruffus import *
 from cgatcore import pipeline as P
+from cgatcore import iotools as IOTools
 import ocmsshotgun.modules.Kraken2 as K
 import ocmstoolkit.modules.Utility as Utility
 

--- a/ocmsshotgun/pipeline_kraken2_benchmark.py
+++ b/ocmsshotgun/pipeline_kraken2_benchmark.py
@@ -62,7 +62,7 @@ from ruffus import *
 from cgatcore import pipeline as P
 from cgatcore import iotools as IOTools
 import ocmsshotgun.modules.Kraken2 as K
-import ocmsshotgun.modules.Utility as utility
+import ocmstoolkit.modules.Utility as Utility
 
 PARAMS = P.get_parameters(["pipeline.yml"])
 try:

--- a/ocmsshotgun/pipeline_kraken2_benchmark.py
+++ b/ocmsshotgun/pipeline_kraken2_benchmark.py
@@ -62,16 +62,17 @@ from ruffus import *
 from cgatcore import pipeline as P
 import ocmsshotgun.modules.Kraken2 as K
 import ocmsshotgun.modules.Utility as utility
+
 PARAMS = P.get_parameters(["pipeline.yml"])
-
-# check files to be processed
-FASTQ1 = utility.check_input()
-
-#get all files within the directory to process
-SEQUENCEFILES = ("*.fastq.1.gz")
-
-SEQUENCEFILES_REGEX = regex(
-    r"(\S+)/(\S+).fastq.1.gz")
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    indir = "."
+    FASTQ1S = None
+else:
+    # check that input files correspond
+    indir = PARAMS.get("general_input.dir", "input.dir")
+    FASTQ1S = Utility.get_fastns(indir)
 
 ########################################################
 ########################################################
@@ -92,7 +93,7 @@ SEQUENCEFILES_REGEX = regex(
          mkdir("confidence_09.dir"),
          mkdir("confidence_10.dir"))
 
-@split(SEQUENCEFILES, "confidence_*.dir/*.fastq.1.gz")
+@split(FASTQ1S, "confidence_*.dir/*.fastq.1.gz")
 def linkInputs(infiles, outfiles):
     '''
     link the original input files to new
@@ -123,7 +124,7 @@ def linkInputs(infiles, outfiles):
 ########################################################
 ########################################################
 @transform(linkInputs, 
-           SEQUENCEFILES_REGEX, 
+           regex(r"(\S+)/(\S+).fastq.1.gz"), 
            r"\1/\2.k2.report.tsv")
 def runKraken2(infile, outfile):
     '''classify reads with kraken2

--- a/ocmsshotgun/pipeline_kraken2_benchmark.py
+++ b/ocmsshotgun/pipeline_kraken2_benchmark.py
@@ -60,6 +60,7 @@ import yaml
 from pathlib import Path
 from ruffus import *
 from cgatcore import pipeline as P
+from cgatcore import iotools as IOTools
 import ocmsshotgun.modules.Kraken2 as K
 import ocmsshotgun.modules.Utility as utility
 

--- a/ocmsshotgun/pipeline_preprocess.py
+++ b/ocmsshotgun/pipeline_preprocess.py
@@ -53,26 +53,28 @@ from cgatcore import iotools as IOTools
 from cgatcore import experiment as E
 
 import os,sys
-import warnings
 
 import ocmstoolkit.modules.Utility as Utility
 import ocmsshotgun.modules.PreProcess as PP
 
 # set up params
 PARAMS = P.get_parameters(["pipeline.yml"])
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    indir = "."
+    FASTQ1S = None
+else:
+    # check that input files correspond
+    indir = PARAMS.get("general_input.dir", "input.dir")
+    FASTQ1S = Utility.get_fastns(indir)
 
-indir = PARAMS.get("general_input.dir", "input.dir")
-# check that input files correspond
-FASTQ1S = Utility.get_fastns(indir)
-warnings.warn("=================================================")
-out = '\n'.join(FASTQ1S)
-warnings.warn(f"\n{out}")
 ###############################################################################
 # Deduplicate
 ###############################################################################
 @follows(mkdir('reads_deduped.dir'))
 @transform(FASTQ1S,
-           regex(fr'{indir}/(.+).fastq.1.gz'),
+           regex(r'.+/(.+).fastq.1.gz'),
            r"reads_deduped.dir/\1_deduped.fastq.1.gz")
 def removeDuplicates(fastq1, outfile):
     '''Filter exact duplicates, if specified in config file'''

--- a/ocmsshotgun/pipeline_preprocess.py
+++ b/ocmsshotgun/pipeline_preprocess.py
@@ -51,9 +51,7 @@ from ruffus import *
 from cgatcore import pipeline as P
 from cgatcore import iotools as IOTools
 from cgatcore import experiment as E
-
 import os,sys
-
 import ocmstoolkit.modules.Utility as Utility
 import ocmsshotgun.modules.PreProcess as PP
 

--- a/ocmsshotgun/pipeline_remove_host.py
+++ b/ocmsshotgun/pipeline_remove_host.py
@@ -48,19 +48,23 @@ import os,sys
 import ocmstoolkit.modules.Utility as Utility
 import ocmsshotgun.modules.PreProcess as PP
 
-# set up params
 PARAMS = P.get_parameters(["pipeline.yml"])
-
-# check that input files correspond
-indir = PARAMS.get('general_input.dir', 'input.dir')
-FASTQ1S = Utility.get_fastns(indir)
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    indir = "."
+    FASTQ1S = None
+else:
+    # check that input files correspond
+    indir = PARAMS.get("general_input.dir", "input.dir")
+    FASTQ1S = Utility.get_fastns(indir)
 
 ################################################################################
 # remove host sequences with bmtagger or hisat
 ################################################################################
 @follows(mkdir('reads_hostRemoved.dir'))
 @transform(FASTQ1S,
-           regex(fr'{indir}/(\S+)_rRNAremoved.fastq.1.gz$'),
+           regex(r'.+/(\S+)_rRNAremoved.fastq.1.gz$'),
            r'reads_hostRemoved.dir/\1_dehost.fastq.1.gz')
 def alignAndRemoveHost(infile,outfile): 
     '''Align and remove host sequences with bmtagger or HISAT2


### PR DESCRIPTION
… having input files' also tidied up unnecessary warnings and imports

addresses #89 

I've tested this, and add try catch on opening pipeline.yml seems to address us wanting to be able to use `config` without existing input files/directory