### PR TITLE
Add fallback to input.dir in pipeline_metaphlan.py to prevent KeyError during config generation

### DIFF
--- a/ocmsshotgun/pipeline_metaphlan.py
+++ b/ocmsshotgun/pipeline_metaphlan.py
@@ -8,7 +8,7 @@ from cgatcore import pipeline as P
 import ocmstoolkit.modules.Utility as Utility
 
 PARAMS = P.get_parameters("pipeline.yml")
-indir=PARAMS["general_input.dir"]
+indir=PARAMS.get("general_input.dir", "input.dir")
 
 #check all files to be processed
 FASTQs = Utility.get_fastns(indir)

--- a/ocmsshotgun/pipeline_metaphlan.py
+++ b/ocmsshotgun/pipeline_metaphlan.py
@@ -5,13 +5,19 @@ import glob
 from pathlib import Path
 from ruffus import *
 from cgatcore import pipeline as P
+from cgatcore import iotools as IOTools
 import ocmstoolkit.modules.Utility as Utility
 
-PARAMS = P.get_parameters("pipeline.yml")
-indir=PARAMS.get("general_input.dir", "input.dir")
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError:
+    raise RuntimeError("Required configuration file 'pipeline.yml' not found. Please provide one to run the pipeline.")
+else:
+    PARAMS = P.get_parameters("pipeline.yml")
+    indir = PARAMS.get("general_input.dir", "input.dir")
 
-#check all files to be processed
-FASTQs = Utility.get_fastns(indir)
+    # Check all files to be processed
+    FASTQs = Utility.get_fastns(indir)
 
 @follows(mkdir("metaphlan.dir"))
 @transform(FASTQs,


### PR DESCRIPTION
This PR addresses an issue encountered when running the following command to generate a config file:

ocms_shotgun metaphlan config
Previously, the pipeline raised a KeyError even when general_input.dir was defined in pipeline.yml. This issue occurred due to the way the parameter was being accessed.

To fix this, the line:
indir = PARAMS["general_input.dir"]
has been updated to:
indir = PARAMS.get("general_input.dir", "input.dir")

This change ensures that if general_input.dir is not explicitly defined, the pipeline will safely fall back to using "input.dir" as the default input directory. The update resolves the issue and allows the config file to be generated successfully.

Impact:
Prevents pipeline failure due to a missing configuration parameter.
Makes pipeline_metaphlan.py more robust and user-friendly.
