### PR TITLE
humann3: update database paths for MetaPhlAn 4.1 and HUMAnN 3.9 in yml

### DIFF
--- a/ocmsshotgun/pipeline_humann3/pipeline.yml
+++ b/ocmsshotgun/pipeline_humann3/pipeline.yml
@@ -6,11 +6,19 @@ general:
     transcriptome: 
 
 humann3:
-    # database settings 
-    db_metaphlan_path: /well/kir/mirror/metaphlan3/metaphlan_databases_3.1
-    db_metaphlan_id: mpa_v31_CHOCOPhlAn_201901
-    db_nucleotide: /well/kir/mirror/humann3/chocophlan
-    db_protein: /well/kir/mirror/humann3/uniref/uniref90
+    
+    # === DATABASE SETTINGS ===
+    # For HUMAnN 3.9 and MetaPhlAn 4, use the following paths:
+    db_metaphlan_path: /gpfs3/well/powrie/shared/metaphlan4/bowtie2index/mpa_vJun23_CHOCOPhlAnSGB_202403 
+    db_metaphlan_id: mpa_vJun23_CHOCOPhlAnSGB_202403
+    db_nucleotide: /gpfs3/well/kir/projects/mirror/humann3/v3.9/chocophlan
+    db_protein: /gpfs3/well/kir/projects/mirror/humann3/v3.9/uniref/
+
+    # For HUMAnN 3.8 and MetaPhlAn 3, use the paths below instead:
+    # db_metaphlan_path: /well/kir/mirror/metaphlan3/metaphlan_databases_3.1
+    # db_metaphlan_id: mpa_v31_CHOCOPhlAn_201901
+    # db_nucleotide: /well/kir/mirror/humann3/chocophlan
+    # db_protein: /well/kir/mirror/humann3/uniref/uniref90
     
     search_mode: uniref90
     

--- a/ocmsshotgun/pipeline_humann3/pipeline.yml
+++ b/ocmsshotgun/pipeline_humann3/pipeline.yml
@@ -9,7 +9,7 @@ humann3:
     
     # === DATABASE SETTINGS ===
     # For HUMAnN 3.9 and MetaPhlAn 4, use the following paths:
-    db_metaphlan_path: /gpfs3/well/powrie/shared/metaphlan4/bowtie2index/mpa_vJun23_CHOCOPhlAnSGB_202403 
+    db_metaphlan_path: /well/kir/projects/mirror/ocms/databases/metaphlan/python-3.11.3/metaphlan-4/ 
     db_metaphlan_id: mpa_vJun23_CHOCOPhlAnSGB_202403
     db_nucleotide: /gpfs3/well/kir/projects/mirror/humann3/v3.9/chocophlan
     db_protein: /gpfs3/well/kir/projects/mirror/humann3/v3.9/uniref/


### PR DESCRIPTION
This PR updates the database paths in pipeline_humann3.yml to point to the centralized locations for MetaPhlAn 4.1 and HUMAnN 3.9.
•	Added new default database paths for MetaPhlAn 4.1 and HUMAnN 3.9
•	Kept old Metaphlanv3.1 and Humann3.8 paths in comments for reference
•	Ensures all users reference shared, centralized database locations
Related issue: [#107](https://github.com/OxfordCMS/OCMS_Shotgun/issues/107)