### PR TITLE
Allow config creation without pipeline.yml and add execution-time input checks

### DIFF
--- a/ocmsshotgun/pipeline_humann3.py
+++ b/ocmsshotgun/pipeline_humann3.py
@@ -70,21 +70,21 @@ import re
 import shutil
 from ruffus import *
 from cgatcore import pipeline as P
-
+from cgatcore import iotools as IOTools
 import ocmstoolkit.modules.Utility as Utility
 import ocmsshotgun.modules.Humann3 as H
 
 # load options from the config file
 PARAMS = P.get_parameters(["pipeline.yml"])
-indir = PARAMS.get('general_input.dir','input.dir')
-
-# check all files to be processed
-FASTQ1s = Utility.get_fastns(indir)
-
-if PARAMS['general_transcriptome']:
-    FASTQ2s = Utility.get_fastns(PARAMS['general_transcriptome'])
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError as e:
+    indir = "."
+    FASTQ1S = None
 else:
-    FASTQ2s = None
+    # check that input files correspond
+    indir = PARAMS.get("general_input.dir", "input.dir")
+    FASTQ1S = Utility.get_fastns(indir)
 
 ###############################################################################
 # Run humann3 on concatenated fastq.gz

--- a/ocmsshotgun/pipeline_metaphlan.py
+++ b/ocmsshotgun/pipeline_metaphlan.py
@@ -8,7 +8,7 @@ from cgatcore import pipeline as P
 import ocmstoolkit.modules.Utility as Utility
 
 PARAMS = P.get_parameters("pipeline.yml")
-indir=PARAMS["general_input.dir"]
+indir=PARAMS.get("general_input.dir", "input.dir")
 
 #check all files to be processed
 FASTQs = Utility.get_fastns(indir)

--- a/ocmsshotgun/pipeline_metaphlan.py
+++ b/ocmsshotgun/pipeline_metaphlan.py
@@ -5,13 +5,19 @@ import glob
 from pathlib import Path
 from ruffus import *
 from cgatcore import pipeline as P
+from cgatcore import iotools as IOTools
 import ocmstoolkit.modules.Utility as Utility
 
-PARAMS = P.get_parameters("pipeline.yml")
-indir=PARAMS.get("general_input.dir", "input.dir")
+try:
+    IOTools.open_file("pipeline.yml")
+except FileNotFoundError:
+    raise RuntimeError("Required configuration file 'pipeline.yml' not found. Please provide one to run the pipeline.")
+else:
+    PARAMS = P.get_parameters("pipeline.yml")
+    indir = PARAMS.get("general_input.dir", "input.dir")
 
-#check all files to be processed
-FASTQs = Utility.get_fastns(indir)
+    # Check all files to be processed
+    FASTQs = Utility.get_fastns(indir)
 
 @follows(mkdir("metaphlan.dir"))
 @transform(FASTQs,

--- a/ocmsshotgun/pipeline_metaphlan.py
+++ b/ocmsshotgun/pipeline_metaphlan.py
@@ -8,6 +8,8 @@ from cgatcore import pipeline as P
 from cgatcore import iotools as IOTools
 import ocmstoolkit.modules.Utility as Utility
 
+# load options from the config file
+PARAMS = P.get_parameters(["pipeline.yml"])
 try:
     IOTools.open_file("pipeline.yml")
 except FileNotFoundError:

--- a/ocmsshotgun/pipeline_metaphlan.py
+++ b/ocmsshotgun/pipeline_metaphlan.py
@@ -8,14 +8,7 @@ from cgatcore import pipeline as P
 from cgatcore import iotools as IOTools
 import ocmstoolkit.modules.Utility as Utility
 
-# Safe import (so config works)
-if os.path.exists("pipeline.yml"):
-    PARAMS = P.get_parameters("pipeline.yml")
-    indir = PARAMS.get("general_input.dir", "input.dir")
-    FASTQs = Utility.get_fastns(indir) if os.path.exists(indir) else []
-else:
-    PARAMS = {}
-    FASTQs = []
+PARAMS, FASTQs = Utility.load_params_safe(P)
 
 @follows(mkdir("metaphlan.dir"))
 @transform(FASTQs,
@@ -140,32 +133,17 @@ def extractTaxonomyLevelsCounts(infile, outfiles):
 def full():
     pass
 
+
 def main(argv=None):
-    if argv is None:
-        argv = sys.argv
+    argv = argv or sys.argv
 
-    # If actually running the pipeline (not config/help), enforce checks
-    if "config" not in argv and "-h" not in argv and "--help" not in argv:
-        if not os.path.exists("pipeline.yml"):
-            raise RuntimeError(
-                "pipeline.yml not found.\n"
-                "Create one using:\n"
-                "  ocms_shotgun pipeline_metaphlan config"
-            )
+    # validate startup; returns (PARAMS, FASTQs) or raises RuntimeError
+    PARAMS, FASTQs = Utility.ensure_pipeline_ready(argv, P)
 
-        PARAMS = P.get_parameters("pipeline.yml")
-        indir = PARAMS.get("general_input.dir", "input.dir")
-
-        if not os.path.exists(indir):
-            raise RuntimeError(f"Input directory '{indir}' does not exist.")
-
-        fastqs = Utility.get_fastns(indir)
-        if not fastqs:
-            raise RuntimeError(f"No FASTQ files found in '{indir}'.")
+    # optional: make PARAMS available globally (some code expects global PARAMS)
+    globals()['PARAMS'] = PARAMS
 
     return P.main(argv)
 
-
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
-
+    sys.exit(main())

--- a/ocmsshotgun/pipeline_metaphlan.py
+++ b/ocmsshotgun/pipeline_metaphlan.py
@@ -8,18 +8,14 @@ from cgatcore import pipeline as P
 from cgatcore import iotools as IOTools
 import ocmstoolkit.modules.Utility as Utility
 
-# load options from the config file
-PARAMS = P.get_parameters(["pipeline.yml"])
-try:
-    IOTools.open_file("pipeline.yml")
-except FileNotFoundError:
-    raise RuntimeError("Required configuration file 'pipeline.yml' not found. Please provide one to run the pipeline.")
-else:
+# Safe import (so config works)
+if os.path.exists("pipeline.yml"):
     PARAMS = P.get_parameters("pipeline.yml")
     indir = PARAMS.get("general_input.dir", "input.dir")
-
-    # Check all files to be processed
-    FASTQs = Utility.get_fastns(indir)
+    FASTQs = Utility.get_fastns(indir) if os.path.exists(indir) else []
+else:
+    PARAMS = {}
+    FASTQs = []
 
 @follows(mkdir("metaphlan.dir"))
 @transform(FASTQs,
@@ -147,7 +143,29 @@ def full():
 def main(argv=None):
     if argv is None:
         argv = sys.argv
-    P.main(argv)
+
+    # If actually running the pipeline (not config/help), enforce checks
+    if "config" not in argv and "-h" not in argv and "--help" not in argv:
+        if not os.path.exists("pipeline.yml"):
+            raise RuntimeError(
+                "pipeline.yml not found.\n"
+                "Create one using:\n"
+                "  ocms_shotgun pipeline_metaphlan config"
+            )
+
+        PARAMS = P.get_parameters("pipeline.yml")
+        indir = PARAMS.get("general_input.dir", "input.dir")
+
+        if not os.path.exists(indir):
+            raise RuntimeError(f"Input directory '{indir}' does not exist.")
+
+        fastqs = Utility.get_fastns(indir)
+        if not fastqs:
+            raise RuntimeError(f"No FASTQ files found in '{indir}'.")
+
+    return P.main(argv)
+
 
 if __name__ == "__main__":
-    sys.exit(P.main(sys.argv))
+    sys.exit(main(sys.argv))
+


### PR DESCRIPTION
This PR makes the pipeline_metaphlan module import-safe so that ocms_shotgun pipeline_metaphlan config can generate a pipeline.yml file even when no configuration or input directory exists.

Changes

- Removed the strict import-time requirement for pipeline.yml.
- Added a lightweight validation layer in main() that:
- Raises an error if pipeline.yml is missing during execution.
- Checks that general_input.dir exists.
- Verifies that FASTQ files are present using Utility.get_fastns().
- Ensures that the pipeline fails early and clearly when required inputs are missing.

Behaviour
ocms_shotgun pipeline_metaphlan config now successfully generates a YAML file without requiring an existing pipeline.yml or input.dir.
Running the pipeline without a pipeline.yml throws a clear error instructing the user to generate one.
If the specified input directory does not exist, an error is raised.
If the input directory exists but contains no FASTQ files, an informative error is raised.
If FASTQ files are present, they are detected and validated using Utility.get_fastns().